### PR TITLE
Include Chronicler as Git dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -623,20 +623,24 @@ pyflakes = ">=3.2.0,<3.3.0"
 
 [[package]]
 name = "grimoirelab-chronicler"
-version = "0.0.1rc2"
+version = "0.0.1-rc.2"
 description = "Generator of GrimoireLab events using Perceval data."
 optional = false
-python-versions = "<4.0,>=3.11"
+python-versions = "^3.11"
 groups = ["main"]
-files = [
-    {file = "grimoirelab_chronicler-0.0.1rc2-py3-none-any.whl", hash = "sha256:766dfb980a1775cb83231546aecbdf964473c992489b23396fe2ea72ec369fe2"},
-    {file = "grimoirelab_chronicler-0.0.1rc2.tar.gz", hash = "sha256:61f68e4c60d1674ab76dc4aaf2d0e65f23b2c272003f09eeb9b89f33a423b933"},
-]
+files = []
+develop = false
 
 [package.dependencies]
-click = ">=8.1.7,<9.0.0"
-cloudevents = ">=1.10.1,<2.0.0"
-coverage = ">=7.2.3,<8.0.0"
+click = "^8.1.7"
+cloudevents = "^1.10.1"
+coverage = "^7.2.3"
+
+[package.source]
+type = "git"
+url = "https://github.com/chaoss/grimoirelab-chronicler.git"
+reference = "HEAD"
+resolved_reference = "481c963e83dd92688aec5c28f6ea1ea78854be5b"
 
 [[package]]
 name = "grimoirelab-toolkit"
@@ -979,4 +983,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "173339632652be2703b390e78958f5522df2fa128dc3a84453276b9e1aaf8a97"
+content-hash = "c749b91b2e5e4c062c89b4d87d5b5d90ba78a790a44c8c251480ac4e1e4cfabe"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ mysqlclient = "2.0.3"
 uWSGI = "^2.0"
 grimoirelab-toolkit = {version = "^1.0.2", allow-prereleases = true}
 perceval = {version = "^1.0.2", allow-prereleases = true}
-grimoirelab-chronicler = {version = "^0.0.1rc2", allow-prereleases = true}
+grimoirelab-chronicler = {git = "https://github.com/chaoss/grimoirelab-chronicler.git", allow-prereleases = true}
 django-cors-headers = "^4.6.0"
 djangorestframework = "^3.15.2"
 


### PR DESCRIPTION
Chronicler was previously included as a package dependency, but we decided to set it as a Git dependency because we are not currently releasing packages.