### PR TITLE
[scheduler] Fix re-scheduling tasks bug during maintenance

### DIFF
--- a/src/grimoirelab/core/scheduler/scheduler.py
+++ b/src/grimoirelab/core/scheduler/scheduler.py
@@ -122,7 +122,7 @@ def maintain_tasks() -> None:
     )
 
     for task in tasks:
-        job_db = task.jobs.order_by('scheduled_at').first()
+        job_db = task.jobs.order_by('-scheduled_at').first()
 
         try:
             rq.job.Job.fetch(job_db.uuid, connection=django_rq.get_connection(task.default_job_queue))


### PR DESCRIPTION
Tasks were incorrectly rescheduled during the maintenance phase. The code was taking the data from the first task's job and not from the last one. This caused the task to run from the very beginning, again.