### PR TITLE
[dist] Build UI when the package is installed/built

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
-exclude = .git, .eggs, __pycache__, build, dist, docs, docker, migrations
+exclude = .git, .eggs, __pycache__, build, dist, docs, docker, migrations, ui
 ignore = E129, E402, F841, W504 E128 
 max-line-length = 130

--- a/.gitignore
+++ b/.gitignore
@@ -6,19 +6,19 @@ build
 # Package files
 src/grimoirelab/core/static
 
-# JavaScript files
-node_modules
-dist
-storybook-static
-
 # Local env files
 .env.local
 .env.*.local
 
 # Log files
+logs
+*.log
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+*storybook.log
 
 # Editor directories and files
 .idea
@@ -31,6 +31,18 @@ yarn-error.log*
 .project
 .pydevproject
 .settings
+node_modules
+.DS_Store
+dist
+dist-ssr
+coverage
+*.local
+.yarn/*
+storybook-static
+*.tsbuildinfo
+
+/cypress/videos/
+/cypress/screenshots/
 
 # Documentation
 .eggs/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,9 +23,15 @@ packages = [
 
 include = [
     { path = "grimoirelab/core/templates" },
+    { path = "ui", format = "sdist" },
     { path = "AUTHORS", format = "sdist" },
     { path = "NEWS", format = "sdist" },
     { path = "README.md", format = "sdist" },
+]
+
+exclude = [
+    "ui/tests",
+    "ui/.storybook",
 ]
 
 classifiers = [
@@ -60,6 +66,9 @@ opensearch-py = "^2.8.0"
 fakeredis = "^2.0.0"
 httpretty = "^1.1.4"
 flake8 = ">=7.0"
+
+[tool.poetry.build]
+script = "scripts/build-ui.py"
 
 [build-system]
 requires = ["poetry-core"]

--- a/scripts/build-ui.py
+++ b/scripts/build-ui.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) GrimoireLab Developers
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+import pathlib
+import subprocess
+import sys
+
+
+def yarn(*args):
+    retcode = subprocess.call(["yarn", *list(args)])
+
+    if retcode != 0:
+        sys.exit(retcode)
+
+
+def build_ui():
+    ui_dir = pathlib.Path(__file__).parent.parent.joinpath("ui")
+
+    sys.stderr.write(f"\nBuilding UI in {ui_dir}\n")
+    yarn("--cwd", ui_dir.as_posix(), "install")
+    yarn("--cwd", ui_dir.as_posix(), "build")
+    sys.stderr.write(f"UI built in {ui_dir}\n\n")
+
+
+if __name__ == "__main__":
+    build_ui()


### PR DESCRIPTION
The UI is now built when either `poetry install` or `poetry build` are called. This ensures that the UI will be distributed and installed without extra steps.

This is critical when this git repository is installed as dependency. Previously, only the Python code was installed.

This commit also modifies the `.gitignore` file to make sure that only the UI code is distributed within the source package.

Fixes #26