### PR TITLE
[auth] Add JWT and Session Authentication

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -505,6 +505,31 @@ files = [
 django = ">=4.2"
 
 [[package]]
+name = "djangorestframework-simplejwt"
+version = "5.4.0"
+description = "A minimal JSON Web Token authentication plugin for Django REST Framework"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "djangorestframework_simplejwt-5.4.0-py3-none-any.whl", hash = "sha256:7aec953db9ed4163430c16d086eecb0f028f814ce6bba62b06c25919261e9077"},
+    {file = "djangorestframework_simplejwt-5.4.0.tar.gz", hash = "sha256:cccecce1a0e1a4a240fae80da73e5fc23055bababb8b67de88fa47cd36822320"},
+]
+
+[package.dependencies]
+django = ">=4.2"
+djangorestframework = ">=3.14"
+pyjwt = ">=1.7.1,<3"
+
+[package.extras]
+crypto = ["cryptography (>=3.3.1)"]
+dev = ["Sphinx (>=1.6.5,<2)", "cryptography", "flake8", "freezegun", "ipython", "isort", "pep8", "pytest", "pytest-cov", "pytest-django", "pytest-watch", "pytest-xdist", "python-jose (==3.3.0)", "sphinx_rtd_theme (>=0.1.9)", "tox", "twine", "wheel"]
+doc = ["Sphinx (>=1.6.5,<2)", "sphinx_rtd_theme (>=0.1.9)"]
+lint = ["flake8", "isort", "pep8"]
+python-jose = ["python-jose (==3.3.0)"]
+test = ["cryptography", "freezegun", "pytest", "pytest-cov", "pytest-django", "pytest-xdist", "tox"]
+
+[[package]]
 name = "dulwich"
 version = "0.22.7"
 description = "Python Git Library"
@@ -1019,4 +1044,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "72a4fd698a93f0afd66cd100b4f2e4fb01ba6a653362d5455d3c16e40deaf7d1"
+content-hash = "9f727a159d910bb4e1d023a4a9d29d9978aed6648f8b2364c2d1ba80be8a30cb"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ grimoirelab-chronicler = {git = "https://github.com/chaoss/grimoirelab-chronicle
 django-cors-headers = "^4.6.0"
 djangorestframework = "^3.15.2"
 opensearch-py = "^2.8.0"
+djangorestframework-simplejwt = "^5.4.0"
 
 [tool.poetry.group.dev.dependencies]
 fakeredis = "^2.0.0"

--- a/src/grimoirelab/core/app/urls.py
+++ b/src/grimoirelab/core/app/urls.py
@@ -4,10 +4,19 @@
 from django.urls import path, include, re_path
 from django.views.generic import TemplateView
 
+from rest_framework_simplejwt.views import (
+    TokenObtainPairView,
+    TokenRefreshView,
+)
+from ..views import api_login
+
 from grimoirelab.core.scheduler.urls import urlpatterns as sched_urlpatterns
 from grimoirelab.core.datasources.urls import urlpatterns as datasources_urlpatterns
 
 urlpatterns = [
+    path("login", api_login, name="api_login"),
+    path("token/", TokenObtainPairView.as_view(), name="token_obtain_pair"),
+    path("token/refresh/", TokenRefreshView.as_view(), name="token_refresh"),
     path("scheduler/", include(sched_urlpatterns)),
     path("datasources/", include(datasources_urlpatterns)),
     re_path(r'^(?!static|scheduler).*$', TemplateView.as_view(template_name="index.html"))

--- a/src/grimoirelab/core/config/settings.py
+++ b/src/grimoirelab/core/config/settings.py
@@ -80,6 +80,13 @@ CORS_ALLOW_CREDENTIALS = True
 
 SECRET_KEY = os.environ.get('GRIMOIRELAB_SECRET_KEY', 'fake-key')
 
+
+# Require authentication when using the API.
+# You shouldn't deactivate this option unless you are debugging
+# the system or running it in a trusted and safe environment.
+GRIMOIRELAB_AUTHENTICATION_REQUIRED = True
+
+
 #
 # Application definition - DO NOT MODIFY
 #
@@ -257,7 +264,14 @@ REST_FRAMEWORK = {
         'rest_framework.renderers.JSONRenderer',
     ),
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
-    'PAGE_SIZE': 100
+    'PAGE_SIZE': 100,
+    'DEFAULT_AUTHENTICATION_CLASSES': [
+        'rest_framework.authentication.SessionAuthentication',
+        'rest_framework_simplejwt.authentication.JWTAuthentication',
+    ],
+    'DEFAULT_PERMISSION_CLASSES': [
+        'grimoirelab.core.permissions.IsAuthenticated',
+    ],
 }
 
 #

--- a/src/grimoirelab/core/permissions.py
+++ b/src/grimoirelab/core/permissions.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) GrimoireLab Contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+from django.conf import settings
+from rest_framework.permissions import BasePermission
+
+
+class IsAuthenticated(BasePermission):
+    """
+    Allows access only to authenticated users.
+    When `GRIMOIRELAB_AUTHENTICATION_REQUIRED` setting is False it always has permissions.
+    """
+    def has_permission(self, request, view):
+        if not settings.GRIMOIRELAB_AUTHENTICATION_REQUIRED:
+            return True
+
+        return bool(request.user and request.user.is_authenticated)

--- a/src/grimoirelab/core/runner/commands/admin.py
+++ b/src/grimoirelab/core/runner/commands/admin.py
@@ -18,11 +18,18 @@
 
 from __future__ import annotations
 
+import getpass
+import os
+import sys
 import typing
 
 import click
 import django.core
 import django_rq
+
+from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError
+from django.db import IntegrityError
 
 if typing.TYPE_CHECKING:
     from click import Context
@@ -111,6 +118,72 @@ def _install_static_files():
                                         interactive=False)
 
     click.echo()
+
+
+@admin.command()
+@click.option('--username', help="Specifies the login for the user.")
+@click.option('--is-admin', is_flag=True, default=False,
+              help="Specifies if the user is superuser.")
+@click.option('--no-interactive', is_flag=True, default=False,
+              help="Run the command in no interactive mode.")
+def create_user(username, is_admin, no_interactive):
+    """Create a new user given a username and password"""
+
+    try:
+        if no_interactive:
+            # Use password from environment variable, if provided.
+            password = os.environ.get('GRIMOIRELAB_USER_PASSWORD')
+            if not password or not password.strip():
+                raise click.ClickException("Password cannot be empty.")
+            # Use username from environment variable, if not provided in options.
+            if username is None:
+                username = os.environ.get('GRIMOIRELAB_USER_USERNAME')
+            error = _validate_username(username)
+            if error:
+                click.ClickException(error)
+        else:
+            # Get username
+            if username is None:
+                username = input("Username: ")
+            error = _validate_username(username)
+            if error:
+                click.ClickException(error)
+            # Prompt for a password
+            password = getpass.getpass()
+            password2 = getpass.getpass('Password (again): ')
+            if password != password2:
+                raise click.ClickException("Error: Your passwords didn't match.")
+            if password.strip() == '':
+                raise click.ClickException("Error: Blank passwords aren't allowed.")
+
+        extra_fields = {}
+        if is_admin:
+            extra_fields['is_staff'] = True
+            extra_fields['is_superuser'] = True
+
+        get_user_model().objects.create_user(username=username,
+                                             password=password,
+                                             **extra_fields)
+
+        click.echo("User created successfully.")
+    except KeyboardInterrupt:
+        click.echo("\nOperation cancelled.")
+        sys.exit(1)
+    except IntegrityError:
+        click.echo(f"User '{username}' already exists.")
+        sys.exit(1)
+
+
+def _validate_username(username):
+    """Check if the username is valid and return the error"""
+
+    if not username:
+        return "Username cannot be empty."
+    username_field = get_user_model()._meta.get_field(get_user_model().USERNAME_FIELD)
+    try:
+        username_field.clean(username, None)
+    except ValidationError as e:
+        return '; '.join(e.messages)
 
 
 @admin.group()

--- a/src/grimoirelab/core/scheduler/views.py
+++ b/src/grimoirelab/core/scheduler/views.py
@@ -16,20 +16,16 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
-import json
-
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
 from django.conf import settings
-from django.http import JsonResponse
-from django.views.decorators.csrf import csrf_exempt
-from django.views.decorators.http import require_http_methods
 
 from .scheduler import (
     schedule_task
 )
 
 
-@require_http_methods(["POST"])
-@csrf_exempt
+@api_view(['POST'])
 def add_task(request):
     """Create a Task to fetch items
 
@@ -49,10 +45,7 @@ def add_task(request):
         }
     }
     """
-    try:
-        data = json.loads(request.body)
-    except json.JSONDecodeError:
-        return JsonResponse({"error": "Invalid JSON format."}, status=400)
+    data = request.data
 
     task_type = data['type']
 
@@ -77,4 +70,4 @@ def add_task(request):
         'status': 'ok',
         'message': f"Task {task.id} added correctly"
     }
-    return JsonResponse(response, safe=False)
+    return Response(response, status=200)

--- a/src/grimoirelab/core/views.py
+++ b/src/grimoirelab/core/views.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) GrimoireLab Contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+from django.contrib.auth import authenticate, login
+from rest_framework import permissions
+from rest_framework.decorators import (
+    api_view,
+    permission_classes,
+)
+from rest_framework.response import Response
+
+
+@api_view(['POST'])
+@permission_classes([permissions.AllowAny])
+def api_login(request):
+    username = request.data.get('username')
+    password = request.data.get('password')
+
+    if username is None or password is None:
+        return Response({'detail': 'Please provide username and password.'}, status=400)
+
+    user = authenticate(request, username=username, password=password)
+
+    if user is None:
+        response = {
+            'errors': 'Invalid credentials.'
+        }
+        return Response(response, status=403)
+    else:
+        login(request, user)
+        response = {
+            'user': username,
+            'isAdmin': user.is_superuser,
+        }
+        return Response(response)

--- a/ui/index.html
+++ b/ui/index.html
@@ -7,6 +7,7 @@
     <title>GrimoireLab</title>
   </head>
   <body>
+    {% csrf_token %}
     <div id="app"></div>
     <script type="module" src="/src/main.js"></script>
   </body>


### PR DESCRIPTION
This PR integrates `djangorestframework-simplejwt` and includes two new endpoints for JWT token management: `/token/` for creating tokens and `/token/refresh/` for refreshing tokens. Additionally, it includes a new endpoint `/login/` that enables session login with CSRF token requirements.

GrimoireLab Core can work without authentication by setting `GRIMOIRELAB_AUTHENTICATION_REQUIRED` to `False`, which is intended for debugging purposes.

Fixes https://github.com/chaoss/grimoirelab-core/issues/30