### PR TITLE
Order and filter tasks and jobs

### DIFF
--- a/ui/src/components/JobList.vue
+++ b/ui/src/components/JobList.vue
@@ -6,7 +6,35 @@
         {{ count }}
       </v-chip>
     </h2>
+
+    <v-tabs
+      v-model="tab"
+      :items="tabs"
+      align-tabs="left"
+      class="mb-4"
+      color="primary"
+      height="36"
+      slider-color="primary"
+      @update:model-value="$emit('update:filters', { status: $event, page: 1 })"
+    >
+      <template #tab="{ item }">
+        <v-tab :text="item.text" :value="item.value" class="text-none text-subtitle-2"></v-tab>
+      </template>
+    </v-tabs>
+
+    <div v-if="loading" class="d-flex justify-center pa-4">
+      <v-progress-circular class="mx-auto" color="primary" indeterminate />
+    </div>
+
+    <v-empty-state
+      v-else-if="!loading && count === 0"
+      icon="mdi-magnify"
+      title="No results found"
+      size="52"
+    ></v-empty-state>
+
     <status-card
+      v-else
       v-for="job in jobs"
       :key="job.uuid"
       :status="job.status"
@@ -47,7 +75,7 @@
       :length="pages"
       color="primary"
       density="comfortable"
-      @update:model-value="$emit('update:page', $event)"
+      @update:model-value="$emit('update:filters', { page: $event, status: tab })"
     />
   </div>
 </template>
@@ -58,7 +86,7 @@ import StatusCard from '@/components/StatusCard.vue'
 export default {
   name: 'JobList',
   components: { StatusCard },
-  emits: ['update:page'],
+  emits: ['update:filters'],
   props: {
     jobs: {
       type: Array,
@@ -71,21 +99,40 @@ export default {
     pages: {
       type: Number,
       required: true
+    },
+    loading: {
+      type: Boolean,
+      required: false,
+      default: false
     }
   },
   data() {
     return {
-      page: 1
+      page: 1,
+      tab: 'all',
+      tabs: [
+        { text: 'All', value: 'all' },
+        { text: 'Failed', value: 5 },
+        { text: 'Completed', value: 4 }
+      ]
     }
   },
   methods: {
     formatDate,
     getDuration
+  },
+  watch: {
+    tab() {
+      this.page = 1
+    }
   }
 }
 </script>
 <style lang="scss" scoped>
 .v-card .v-card-title {
   line-height: 1.7rem;
+}
+.v-tab.v-tab.v-btn {
+  min-width: 0;
 }
 </style>

--- a/ui/src/components/OrderSelector.vue
+++ b/ui/src/components/OrderSelector.vue
@@ -1,0 +1,107 @@
+<template>
+  <v-select
+    v-model="selectedValue"
+    :items="options"
+    :list-props="{ nav: true }"
+    :menu-props="{ offsetY: true, bottom: true, nudgeTop: 8 }"
+    density="compact"
+    label="Order by"
+    class="select--segmented"
+    variant="outlined"
+    attach
+    single-line
+    @update:model-value="emitValue"
+  >
+    <template #prepend>
+      <v-tooltip location="bottom">
+        <template #activator="{ props }">
+          <v-btn
+            v-bind="props"
+            variant="text"
+            height="32"
+            @click="changeOrder"
+            @keyup.enter="changeOrder"
+          >
+            <v-icon small>
+              {{ icon }}
+            </v-icon>
+          </v-btn>
+        </template>
+        <span> {{ descending ? 'Descending ' : 'Ascending ' }} order </span>
+      </v-tooltip>
+    </template>
+  </v-select>
+</template>
+<script>
+export default {
+  name: 'OrderSelector',
+  emits: ['update:value'],
+  props: {
+    /** Objects should have title and value properties */
+    options: {
+      type: Array,
+      required: true
+    },
+    default: {
+      type: String,
+      required: false,
+      default: undefined
+    }
+  },
+  data() {
+    return {
+      descending: true,
+      selectedValue: this.default
+    }
+  },
+  computed: {
+    value() {
+      return `${this.descending ? '-' : ''}${this.selectedValue}`
+    },
+    icon() {
+      return this.descending ? 'mdi-sort-descending' : 'mdi-sort-ascending'
+    }
+  },
+  methods: {
+    emitValue() {
+      this.$emit('update:value', this.value)
+    },
+    changeOrder() {
+      this.descending = !this.descending
+      if (this.selectedValue) {
+        this.emitValue()
+      }
+    }
+  }
+}
+</script>
+<style lang="scss" scoped>
+.select--segmented {
+  max-width: fit-content;
+
+  .v-select__selection {
+    margin-top: 0;
+    height: 37px;
+  }
+
+  :deep(.v-field) {
+    font-size: 0.875rem;
+    font-weight: 500;
+  }
+
+  :deep(.v-input__prepend) {
+    border: solid rgba(0, 0, 0, 0.15);
+    border-width: 1px 0 1px 1px;
+    border-radius: 4px 0 0 4px;
+    margin: 0;
+  }
+
+  :deep(.v-input__prepend) + .v-input__control > .v-field--center-affix {
+    border-radius: 0 4px 4px 0;
+  }
+
+  :deep(.v-field__outline) {
+    --v-field-border-opacity: 0.15;
+  }
+}
+</style>

--- a/ui/src/components/StatusIcon.vue
+++ b/ui/src/components/StatusIcon.vue
@@ -1,0 +1,35 @@
+<template>
+  <v-icon :color="status" :size="size">
+    {{ icon }}
+  </v-icon>
+</template>
+<script>
+export default {
+  name: 'StatusIcon',
+  props: {
+    status: {
+      type: String,
+      required: true
+    },
+    size: {
+      type: String,
+      required: false,
+      default: 'small'
+    }
+  },
+  computed: {
+    icon() {
+      switch (this.status) {
+        case 'completed':
+          return 'mdi-check'
+        case 'failed':
+          return 'mdi-alert-circle-outline'
+        case 'running':
+          return 'mdi-sync'
+        default:
+          return 'mdi-clock-outline'
+      }
+    }
+  }
+}
+</script>

--- a/ui/src/components/TaskCard.vue
+++ b/ui/src/components/TaskCard.vue
@@ -21,7 +21,7 @@
             size="small"
             start
           >
-            {{ statusIcon }}
+            <status-icon :status="status" size="x-small" />
           </v-icon>
           Last run {{ lastRunDate }}
         </v-card-subtitle>
@@ -42,6 +42,13 @@
             {{ formattedInterval }}
           </span>
         </p>
+        <p v-if="failures" class="pb-2 text-body-2">
+          <v-icon color="failed" size="small" start> mdi-alert-circle-outline </v-icon>
+          <span class="font-weight-medium">
+            {{ failures }}
+          </span>
+          failure{{ failures > 1 ? 's' : '' }}
+        </p>
       </v-col>
     </v-row>
   </status-card>
@@ -49,10 +56,11 @@
 <script>
 import { formatDate } from '@/utils/dates'
 import StatusCard from '@/components/StatusCard.vue'
+import StatusIcon from './StatusIcon.vue'
 
 export default {
   name: 'TaskCard',
-  components: { StatusCard },
+  components: { StatusCard, StatusIcon },
   props: {
     age: {
       type: [Number, String],
@@ -98,6 +106,11 @@ export default {
       type: String,
       required: false,
       default: null
+    },
+    failures: {
+      type: Number,
+      required: false,
+      default: null
     }
   },
   computed: {
@@ -109,18 +122,6 @@ export default {
           return 'week'
         default:
           return `${this.interval} seconds`
-      }
-    },
-    statusIcon() {
-      switch (this.status) {
-        case 'completed':
-          return 'mdi-check'
-        case 'failed':
-          return 'mdi-close'
-        case 'running':
-          return 'mdi-sync'
-        default:
-          return 'mdi-calendar'
       }
     },
     lastRunDate() {

--- a/ui/src/components/TaskList/TaskList.vue
+++ b/ui/src/components/TaskList/TaskList.vue
@@ -14,6 +14,31 @@
         variant="flat"
       ></v-btn>
     </h1>
+    <div class="d-flex">
+      <v-tabs
+        v-model="tab"
+        :items="tabs"
+        align-tabs="left"
+        color="primary"
+        height="36"
+        slider-color="primary"
+        @update:model-value="emitFilters"
+      >
+        <template #tab="{ item }">
+          <v-tab :text="item.text" :value="item.value" class="text-none text-subtitle-2"></v-tab>
+        </template>
+      </v-tabs>
+      <order-selector
+        :options="[
+          { title: 'Last run', value: 'last_run' },
+          { title: 'Scheduled at', value: 'scheduled_at' }
+        ]"
+        default="last_run"
+        class="ml-auto"
+        @update:value="orderBy = $event"
+      >
+      </order-selector>
+    </div>
 
     <task-list-item
       v-for="task in tasks"
@@ -42,12 +67,13 @@
   </div>
 </template>
 <script>
+import OrderSelector from '../OrderSelector.vue'
 import TaskListItem from './TaskListItem.vue'
 
 export default {
   name: 'TaskList',
-  components: { TaskListItem },
-  emits: ['delete', 'reschedule', 'update:page'],
+  components: { OrderSelector, TaskListItem },
+  emits: ['delete', 'reschedule', 'update:page', 'update:filters'],
   props: {
     tasks: {
       type: Array,
@@ -60,12 +86,43 @@ export default {
     pages: {
       type: Number,
       required: true
+    },
+    loading: {
+      type: Boolean,
+      required: false,
+      default: false
     }
   },
   data() {
     return {
       dialog: false,
-      page: 1
+      page: 1,
+      tab: 'all',
+      tabs: [
+        { text: 'All', value: 'all' },
+        { text: 'Running', value: 3 },
+        { text: 'Failed', value: 5 },
+        { text: 'Enqueued', value: 2 }
+      ],
+      orderBy: null
+    }
+  },
+  methods: {
+    emitFilters() {
+      let filters = {}
+      if (this.tab !== 'all') {
+        Object.assign(filters, { status: this.tab })
+      }
+      if (this.orderBy) {
+        Object.assign(filters, { ordering: this.orderBy })
+      }
+      this.$emit('update:filters', filters)
+    }
+  },
+  watch: {
+    orderBy() {
+      this.emitFilters()
+      this.page = 1
     }
   }
 }
@@ -77,5 +134,8 @@ export default {
   & + .v-selection-control-group {
     padding-inline-start: 0;
   }
+}
+.v-tab.v-tab.v-btn {
+  min-width: 0;
 }
 </style>

--- a/ui/src/components/TaskList/TaskList.vue
+++ b/ui/src/components/TaskList/TaskList.vue
@@ -40,7 +40,19 @@
       </order-selector>
     </div>
 
+    <div v-if="loading" class="d-flex justify-center pa-4">
+      <v-progress-circular class="mx-auto" color="primary" indeterminate />
+    </div>
+
+    <v-empty-state
+      v-else-if="!loading && count === 0"
+      icon="mdi-magnify"
+      title="No results found"
+      size="52"
+    ></v-empty-state>
+
     <task-list-item
+      v-else
       v-for="task in tasks"
       :key="task.uuid"
       :id="task.uuid"

--- a/ui/src/components/TaskList/TaskListItem.vue
+++ b/ui/src/components/TaskList/TaskListItem.vue
@@ -8,60 +8,46 @@
   >
     <v-row>
       <v-col md="6" sm="8">
-        <v-row>
-          <v-col>
-            <v-card-title class="text-subtitle-2 pb-0 d-flex align-center">
-              {{ id }}
-              <v-chip :color="status.toLowerCase()" class="ml-3" density="compact" size="small">
-                {{ status }}
-              </v-chip>
-            </v-card-title>
-            <v-card-subtitle class="font-weight-medium">
-              <v-icon :aria-label="backend" role="img" aria-hidden="false" size="small">
-                {{ 'mdi-' + backend }}
-              </v-icon>
-              {{ category }}
-              <v-tooltip v-if="uri" :text="uri" location="bottom" open-delay="200">
-                <template #activator="{ props }">
-                  <span v-bind="props"> from {{ uri }} </span>
-                </template>
-              </v-tooltip>
-            </v-card-subtitle>
-          </v-col>
-          <v-col class="px-0 py-md-6">
-            <div class="d-flex flex-wrap justify-end">
-              <v-tooltip
-                v-for="job in jobs"
-                :key="job.uuid"
-                :text="`#${job.job_num} ${job.status}`"
-                :eager="false"
-                location="bottom"
-              >
-                <template #activator="{ props }">
-                  <v-icon v-bind="props" :color="job.status"> mdi-square </v-icon>
-                </template>
-              </v-tooltip>
-            </div>
-          </v-col>
-        </v-row>
+        <v-card-title class="text-subtitle-2 d-flex align-center pt-4">
+          {{ id }}
+          <v-chip :color="status.toLowerCase()" class="ml-4" density="compact" size="small">
+            {{ status }}
+          </v-chip>
+        </v-card-title>
+        <v-card-subtitle class="font-weight-medium">
+          <v-icon :aria-label="backend" role="img" aria-hidden="false" size="small">
+            {{ 'mdi-' + backend }}
+          </v-icon>
+          {{ category }}
+        </v-card-subtitle>
       </v-col>
       <v-divider vertical></v-divider>
-      <v-col md="4" class="px-4 py-6">
-        <p class="pb-2 text-body-2">
-          <v-icon color="medium-emphasis" size="small" start> mdi-format-list-numbered </v-icon>
-          <span class="font-weight-medium">
-            {{ executions }}
+      <v-col md="4" class="px-4 py-7">
+        <div class="d-flex flex-wrap mb-3">
+          <v-tooltip
+            v-for="job in [...jobs].reverse()"
+            :key="job.uuid"
+            :text="`#${job.job_num} ${job.status}`"
+            :eager="false"
+            location="bottom"
+          >
+            <template #activator="{ props }">
+              <div v-bind="props" :class="`bg-${job.status}`" class="job-run mr-2" />
+            </template>
+          </v-tooltip>
+          <span v-if="executions > 9" class="caption border text-medium-emphasis px-1">
+            + {{ executions - 9 }}
           </span>
-          executions
-        </p>
-        <p class="text-body-2">
-          <v-icon color="medium-emphasis" size="small" start> mdi-calendar </v-icon>
-          Last run {{ executionDate }}
+        </div>
+        <p class="text-body-2 d-flex align-baseline" v-if="latestRun">
+          <status-icon :status="latestRun.status" size="x-small" start />
+          Last run {{ latestRun.date }}
         </p>
       </v-col>
-      <v-col class="mx-4 py-6 d-flex flex-column align-end">
+      <v-col class="pa-6 d-flex flex-column align-end">
         <v-btn
           icon="mdi-delete"
+          class="mb-1"
           color="danger"
           variant="text"
           size="small"
@@ -82,10 +68,11 @@
 <script>
 import { formatDate } from '@/utils/dates'
 import StatusCard from '@/components/StatusCard.vue'
+import StatusIcon from '../StatusIcon.vue'
 
 export default {
   name: 'TaskListItem',
-  components: { StatusCard },
+  components: { StatusCard, StatusIcon },
   emits: ['delete', 'reschedule'],
   props: {
     backend: {
@@ -137,6 +124,17 @@ export default {
       } else {
         return ''
       }
+    },
+    latestRun() {
+      if (this.lastExecution) {
+        const latestStatus = this.status === 'enqueued' ? this.jobs[1].status : this.status
+        return {
+          date: formatDate(this.lastExecution),
+          status: latestStatus
+        }
+      } else {
+        return null
+      }
     }
   }
 }
@@ -144,5 +142,20 @@ export default {
 <style lang="scss" scoped>
 .v-chip.v-chip--density-compact {
   height: calc(var(--v-chip-height) + -6px);
+}
+
+.job-run {
+  width: 0.5rem;
+  height: 1.2rem;
+  border-radius: 2px;
+}
+
+.caption {
+  margin: 0 2px;
+  border-radius: 2px;
+  height: 1.2rem;
+  font-size: 0.7rem;
+  font-weight: 400;
+  line-height: 1.1rem;
 }
 </style>

--- a/ui/src/composables/loading.js
+++ b/ui/src/composables/loading.js
@@ -1,0 +1,35 @@
+import { ref } from 'vue'
+import { API } from '@/services/api'
+
+/** Indicates if the request is currently loading */
+export function useIsLoading() {
+  const isLoading = ref(false)
+
+  API.client.interceptors.request.use(
+    (config) => {
+      isLoading.value = true
+
+      return config
+    },
+    (error) => {
+      isLoading.value = false
+
+      return Promise.reject(error)
+    }
+  )
+
+  API.client.interceptors.response.use(
+    (response) => {
+      isLoading.value = false
+
+      return response
+    },
+    (error) => {
+      isLoading.value = false
+
+      return Promise.reject(error)
+    }
+  )
+
+  return { isLoading }
+}

--- a/ui/src/services/api/index.js
+++ b/ui/src/services/api/index.js
@@ -1,7 +1,9 @@
 import { auth } from './auth'
 import { scheduler } from './scheduler'
+import { client } from './client'
 
 export const API = {
   auth,
-  scheduler
+  scheduler,
+  client
 }

--- a/ui/src/stories/JobList.stories.js
+++ b/ui/src/stories/JobList.stories.js
@@ -38,3 +38,20 @@ export const Default = {
     ]
   }
 }
+
+export const Loading = {
+  args: {
+    loading: true,
+    jobs: [],
+    count: 0,
+    pages: 1
+  }
+}
+
+export const NoData = {
+  args: {
+    jobs: [],
+    count: 0,
+    pages: 1
+  }
+}

--- a/ui/src/stories/OrderSelector.stories.js
+++ b/ui/src/stories/OrderSelector.stories.js
@@ -1,0 +1,17 @@
+import OrderSelector from '@/components/OrderSelector.vue'
+
+export default {
+  title: 'Components/OrderSelector',
+  component: OrderSelector,
+  tags: ['autodocs']
+}
+
+export const Default = {
+  args: {
+    options: [
+      { title: 'Option 1', value: '1' },
+      { title: 'Option 2', value: '2' }
+    ],
+    default: '1'
+  }
+}

--- a/ui/src/stories/StatusIcon.stories.js
+++ b/ui/src/stories/StatusIcon.stories.js
@@ -1,0 +1,26 @@
+import StatusIcon from '@/components/StatusIcon.vue'
+
+export default {
+  title: 'Components/StatusIcon',
+  component: StatusIcon,
+  tags: ['autodocs'],
+  argTypes: {
+    status: {
+      control: { type: 'select' },
+      options: ['enqueued', 'running', 'completed', 'failed']
+    }
+  }
+}
+
+export const Default = {
+  render: (args) => ({
+    components: { StatusIcon },
+    setup() {
+      return { args }
+    },
+    template: '<status-icon v-bind="args" />'
+  }),
+  args: {
+    status: 'enqueued'
+  }
+}

--- a/ui/src/stories/TaskList.stories.js
+++ b/ui/src/stories/TaskList.stories.js
@@ -89,3 +89,20 @@ export const Default = {
     ]
   }
 }
+
+export const Loading = {
+  args: {
+    loading: true,
+    tasks: [],
+    count: 0,
+    pages: 1
+  }
+}
+
+export const NoData = {
+  args: {
+    tasks: [],
+    count: 0,
+    pages: 0
+  }
+}

--- a/ui/src/views/Job/ListView.vue
+++ b/ui/src/views/Job/ListView.vue
@@ -1,16 +1,18 @@
 <template>
   <job-list
-    v-if="jobs.length > 0"
     :jobs="jobs"
     :count="count"
+    :loading="isLoading"
     :pages="pages"
     class="mt-4"
-    @update:page="fetchTaskJobs(this.taskId, $event)"
+    @update:filters="fetchTaskJobs(this.taskId, $event)"
   />
 </template>
 <script>
 import { API } from '@/services/api'
+import { useIsLoading } from '@/composables/loading'
 import JobList from '@/components/JobList.vue'
+
 export default {
   components: { JobList },
   props: {
@@ -34,9 +36,12 @@ export default {
     }
   },
   methods: {
-    async fetchTaskJobs(id = this.taskId, page = 1) {
+    async fetchTaskJobs(id = this.taskId, filters = { page: 1 }) {
+      if (filters.status === 'all') {
+        delete filters.status
+      }
       try {
-        const response = await API.scheduler.getTaskJobs(id, { page })
+        const response = await API.scheduler.getTaskJobs(id, filters)
         if (response.data) {
           this.jobs = response.data.results
           this.count = response.data.count
@@ -50,6 +55,10 @@ export default {
   },
   mounted() {
     this.fetchTaskJobs(this.taskId)
+  },
+  setup() {
+    const { isLoading } = useIsLoading()
+    return { isLoading }
   }
 }
 </script>

--- a/ui/src/views/Task/DetailView.vue
+++ b/ui/src/views/Task/DetailView.vue
@@ -9,6 +9,7 @@
       :category="task.datasource_category"
       :status="task.status"
       :executions="task.runs"
+      :failures="task.failures"
       :interval="task.job_interval"
       :last-execution="task.last_run"
       :max-retries="task.max_retries"

--- a/ui/src/views/Task/ListView.vue
+++ b/ui/src/views/Task/ListView.vue
@@ -3,6 +3,7 @@
     <task-list
       :tasks="tasks"
       :count="count"
+      :loading="isLoading"
       :pages="pages"
       @create="createTask($event)"
       @delete="confirmDeleteTask($event)"
@@ -27,6 +28,7 @@
 </template>
 <script>
 import { API } from '@/services/api'
+import { useIsLoading } from '@/composables/loading'
 import TaskList from '@/components/TaskList/TaskList.vue'
 
 export default {
@@ -128,6 +130,10 @@ export default {
         })
       }
     }
+  },
+  setup() {
+    const { isLoading } = useIsLoading()
+    return { isLoading }
   }
 }
 </script>

--- a/ui/src/views/Task/ListView.vue
+++ b/ui/src/views/Task/ListView.vue
@@ -8,6 +8,8 @@
       @delete="confirmDeleteTask($event)"
       @reschedule="rescheduleTask($event)"
       @update:page="fetchTasks($event)"
+      @update:status="fetchTasks(this.page, $event)"
+      @update:filters="fetchTasks(this.page, $event)"
     />
     <v-snackbar v-model="snackbar.open" :color="snackbar.color">
       {{ snackbar.text }}
@@ -92,9 +94,13 @@ export default {
       }
       this.dialog = false
     },
-    async fetchTasks(page = 1) {
+    async fetchTasks(page = 1, filters) {
       try {
-        const response = await API.scheduler.list({ page })
+        const params = { page }
+        if (filters) {
+          Object.assign(params, filters)
+        }
+        const response = await API.scheduler.list(params)
         if (response.data.results) {
           this.tasks = response.data.results
           this.count = response.data.count

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -7946,9 +7946,9 @@ vue@^3.4.21:
     "@vue/shared" "3.4.24"
 
 vuetify@^3.5.9:
-  version "3.5.16"
-  resolved "https://registry.yarnpkg.com/vuetify/-/vuetify-3.5.16.tgz#5046aab39bfa536f0d99c5be4f9d91a7245c3246"
-  integrity sha512-jyApfATreFMkgjvK0bL7ntZnr+p9TU73+4E3kX6fIvUitdAP9fltG7yj+v3k14HLqZRSNhTL1GhQ95DFx631zw==
+  version "3.7.12"
+  resolved "https://registry.yarnpkg.com/vuetify/-/vuetify-3.7.12.tgz#17fa7e7a88ba8495d7162ad64916ea91e63875cf"
+  integrity sha512-cBxWXKPNl3vWc10/EEpfK4RBrCZERAHEUZCWmrJPd6v+JU0sbm4sEgIpy8IU5d1BzA1kIhknpbgYy2IqiZponA==
 
 w3c-xmlserializer@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
This PR adds the option to filter the list of tasks and jobs by status, both on the API and the UI. The task list is ordered by latest run by default, with currently running tasks first.

It also adds some small improvements to the UI:
- Adds a spinner if the tasks or jobs are loading.
- Shows the last 10 jobs run in order and indicates if there are more than those 10 runs.
- The icon next to the last run info shows its status instead of the status of the task (which is usually 'enqueued').
- Shows the number of failures of the task if there have been any.