### PR TITLE
[api] Add remove_task and reschedule_task to the API

### DIFF
--- a/src/grimoirelab/core/scheduler/urls.py
+++ b/src/grimoirelab/core/scheduler/urls.py
@@ -24,6 +24,8 @@ from . import views
 
 urlpatterns = [
     re_path(r'^add_task', views.add_task),
+    re_path(r'^reschedule_task', views.reschedule_task),
+    re_path(r'^remove_task', views.remove_task),
     path('tasks/', api.EventizerTaskList.as_view()),
     path('tasks/<str:uuid>/', api.EventizerTaskDetail.as_view()),
     path('tasks/<str:task_id>/jobs/', api.EventizerJobList.as_view()),

--- a/src/grimoirelab/core/scheduler/views.py
+++ b/src/grimoirelab/core/scheduler/views.py
@@ -21,7 +21,9 @@ from rest_framework.response import Response
 from django.conf import settings
 
 from .scheduler import (
-    schedule_task
+    cancel_task,
+    schedule_task,
+    reschedule_task as scheduler_reschedule_task
 )
 
 
@@ -69,5 +71,47 @@ def add_task(request):
     response = {
         'status': 'ok',
         'message': f"Task {task.id} added correctly"
+    }
+    return Response(response, status=200)
+
+
+@api_view(['POST'])
+def reschedule_task(request):
+    """Reschedule a Task
+
+    The body should contain the task id to reschedule:
+    {
+        'taskId': 'task_id'
+    }
+    """
+    data = request.data
+    task_id = data['taskId']
+
+    scheduler_reschedule_task(task_id)
+
+    response = {
+        'status': 'ok',
+        'message': f"Task {task_id} rescheduled correctly"
+    }
+    return Response(response, status=200)
+
+
+@api_view(['POST'])
+def remove_task(request):
+    """Remove a Task
+
+    The body should contain the task id to remove:
+    {
+        'taskId': 'task_id'
+    }
+    """
+    data = request.data
+    task_id = data['taskId']
+
+    cancel_task(task_id)
+
+    response = {
+        'status': 'ok',
+        'message': f"Task {task_id} removed correctly"
     }
     return Response(response, status=200)


### PR DESCRIPTION
This PR introduces two new endpoints to manage tasks through both the API and the UI. You can now reschedule a failed task to run immediately or remove a task from the registry to stop its analysis.

Additionally, this commit fixes edge cases where tasks could become stuck in an inconsistent state.