### PR TITLE
Handle scheduler corner cases of execution

### DIFF
--- a/src/grimoirelab/core/scheduler/tasks/models.py
+++ b/src/grimoirelab/core/scheduler/tasks/models.py
@@ -135,10 +135,13 @@ class EventizerTask(Task):
             job_args = args_gen.resuming_args(job.job_args['job_args'], progress)
         elif self.status == SchedulerStatus.RECOVERY:
             job = self.jobs.all().order_by('-job_num').first()
-            progress = ChroniclerProgress.from_dict(job.progress)
-            job_args = args_gen.recovery_args(job.job_args['job_args'], progress)
+            if job and job.progress:
+                progress = ChroniclerProgress.from_dict(job.progress)
+                job_args = args_gen.recovery_args(job.job_args['job_args'], progress)
+            else:
+                job_args = args_gen.initial_args(self.task_args)
         else:
-            job_args = self.task_args
+            job_args = args_gen.initial_args(self.task_args)
 
         task_args['job_args'] = job_args
 


### PR DESCRIPTION
This PR fixes two scenarios where the scheduler could fail

- If a worker is forcibly stopped, the job may remain in the STARTED status. This update adds a check for expired jobs by comparing the job's expiration date with the current time when the status is STARTED and no heartbeat is detected.

- Before generating recovery arguments, this change verifies job progress. If progress is unavailable, it defaults to the initial arguments. It also generates initial arguments from the task when the task status is neither RECOVERY nor COMPLETED.