### PR TITLE
[scheduler] Fix missing job progress on job completion

### DIFF
--- a/src/grimoirelab/core/scheduler/tasks/models.py
+++ b/src/grimoirelab/core/scheduler/tasks/models.py
@@ -131,8 +131,11 @@ class EventizerTask(Task):
             job_args = args_gen.initial_args(self.task_args)
         elif self.status == SchedulerStatus.COMPLETED:
             job = self.jobs.all().order_by('-job_num').first()
-            progress = ChroniclerProgress.from_dict(job.progress)
-            job_args = args_gen.resuming_args(job.job_args['job_args'], progress)
+            if job and job.progress:
+                progress = ChroniclerProgress.from_dict(job.progress)
+                job_args = args_gen.resuming_args(job.job_args['job_args'], progress)
+            else:
+                job_args = args_gen.initial_args(self.task_args)
         elif self.status == SchedulerStatus.RECOVERY:
             job = self.jobs.all().order_by('-job_num').first()
             if job and job.progress:


### PR DESCRIPTION
This change adds a check for job progress before generating the resuming arguments. If progress is not available, it defaults to the initial arguments, as the resuming arguments can't be obtained from the job result.