### PR TITLE
[ui] Remove default value for base API URL

### DIFF
--- a/ui/src/services/api/client.js
+++ b/ui/src/services/api/client.js
@@ -1,6 +1,7 @@
 import axios from 'axios'
 
-const base = import.meta.env.VITE_API_ENDPOINT || 'http://localhost:8000'
+const defaultBase = import.meta.env.MODE === 'development' ? 'http://localhost:8000' : "/"
+const base = import.meta.env.VITE_API_ENDPOINT || defaultBase
 
 export const client = axios.create({
   baseURL: base,


### PR DESCRIPTION
This PR sets the default API base URL to `http://localhost:8000` only in development mode and `/`  in every other case. By default `yarn serve` runs in development mode and `yarn build` runs in production mode.

The base URL can be changed with the `VITE_API_ENDPOINT` env variable.