### PR TITLE
Improve failed tasks filter

### DIFF
--- a/ui/src/components/TaskList/TaskList.vue
+++ b/ui/src/components/TaskList/TaskList.vue
@@ -117,9 +117,10 @@ export default {
       tab: 'all',
       tabs: [
         { text: 'All', value: 'all' },
-        { text: 'Running', value: 3 },
-        { text: 'Failed', value: 5 },
-        { text: 'Enqueued', value: 2 }
+        { text: 'Running', value: { status: 3 } },
+        { text: 'Failed', value: { status: 5 } },
+        { text: 'Failed last run', value: { last_run_status: 5 } },
+        { text: 'Enqueued', value: { status: 2 } }
       ],
       orderBy: null
     }
@@ -128,7 +129,7 @@ export default {
     emitFilters() {
       let filters = {}
       if (this.tab !== 'all') {
-        Object.assign(filters, { status: this.tab })
+        Object.assign(filters, this.tab)
       }
       if (this.orderBy) {
         Object.assign(filters, { ordering: this.orderBy })


### PR DESCRIPTION
The `status` filter is not very useful when searching for failed tasks since tasks rarely have that status. This PR changes the `status` filter in the eventizer task list endpoint to return all tasks that have failed at some point in their run history when filtering for failed tasks. It also adds a `last_run_status` filter and a tab in the UI to show tasks that have failed in their last execution.