### PR TITLE
[ui] Reload task jobs when task changes

### DIFF
--- a/ui/src/views/Job/ListView.vue
+++ b/ui/src/views/Job/ListView.vue
@@ -29,7 +29,8 @@ export default {
       currentPage: 1,
       count: 0,
       pollID: null,
-      interval: 30000
+      interval: 30000,
+      filters: {}
     }
   },
   computed: {
@@ -49,6 +50,7 @@ export default {
           this.count = response.data.count
           this.pages = response.data.total_pages
           this.currentPage = response.data.page
+          this.filters = filters
         }
       } catch (error) {
         console.log(error)
@@ -61,7 +63,7 @@ export default {
       } catch (error) {
         console.log(error)
       } finally {
-        this.pollID = setTimeout(() => (this.pollJobs(filters)), this.interval)
+        this.pollID = setTimeout(() => this.pollJobs(filters), this.interval)
       }
     }
   },
@@ -74,6 +76,13 @@ export default {
   setup() {
     const { isLoading } = useIsLoading()
     return { isLoading }
+  },
+  watch: {
+    task(oldValue, newValue) {
+      if (newValue.status) {
+        this.pollJobs(this.filters)
+      }
+    }
   }
 }
 </script>

--- a/ui/src/views/Task/DetailView.vue
+++ b/ui/src/views/Task/DetailView.vue
@@ -27,7 +27,7 @@
 <script setup>
 import { onMounted, ref } from 'vue'
 import { API } from '@/services/api'
-import { useRouter, useRoute } from 'vue-router'
+import { useRoute } from 'vue-router'
 import TaskCard from '@/components/TaskCard.vue'
 import ConfirmModal from '@/components/ConfirmModal.vue'
 import useModal from '@/composables/useModal'
@@ -35,7 +35,6 @@ import useSnackbar from '@/composables/useSnackbar'
 
 const { closeModal, confirmCancel, modalProps } = useModal()
 const { openErrorSnackbar, openSnackbar, snackbarProps } = useSnackbar()
-const router = useRouter()
 const route = useRoute()
 const task = ref({})
 
@@ -50,7 +49,11 @@ async function cancelTask(id) {
   closeModal()
   try {
     await API.scheduler.cancel(id)
-    router.push({ name: 'taskList' })
+    openSnackbar({
+      color: 'success',
+      text: 'Canceled task'
+    })
+    fetchTask(id)
   } catch (error) {
     openErrorSnackbar(error)
   }
@@ -63,7 +66,7 @@ async function rescheduleTask(id) {
       color: 'success',
       text: 'Rescheduled task'
     })
-    this.fetchTask(id)
+    fetchTask(id)
   } catch (error) {
     openErrorSnackbar(error)
   }


### PR DESCRIPTION
Reloads a task's list of jobs when the task data changes, eg. when it is rescheduled or canceled.