### PR TITLE
[ci] Add permissions to the test workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,9 @@ on:
     branches:
       - '**'
 
+permissions:
+  contents: read
+
 jobs:
 
   backend:


### PR DESCRIPTION
The jobs of the test workflow only need the minimum permissions to run. In this case, we limit the scope to the minimal starting point that is 'read' privileges for 'content' access. All other scopes ('issues', 'pull-requests', etc) are set to 'none' when they aren't defined.