### PR TITLE
Auto-generate slug

### DIFF
--- a/src/grimoirelab/core/datasources/api.py
+++ b/src/grimoirelab/core/datasources/api.py
@@ -116,6 +116,8 @@ class ProjectDetailSerializer(ProjectSerializer):
 
 
 class EcosystemSerializer(serializers.ModelSerializer):
+    description = serializers.CharField(required=False, allow_blank=True)
+
     class Meta:
         model = Ecosystem
         fields = [

--- a/ui/src/components/EcosystemModal.vue
+++ b/ui/src/components/EcosystemModal.vue
@@ -14,6 +14,7 @@
               hide-details
               persistent-placeholder
               required
+              @change="generateSlug(form.title, $refs.slug)"
             />
           </v-col>
         </v-row>
@@ -29,6 +30,7 @@
               persistent-hint
               persistent-placeholder
               required
+              ref="slug"
             />
           </v-col>
         </v-row>
@@ -59,6 +61,7 @@
 <script>
 import Cookies from 'js-cookie'
 import { useEcosystemStore } from '@/store'
+import { generateSlug } from '@/utils/datasources'
 
 export default {
   name: 'EcosystemModal',
@@ -101,7 +104,7 @@ export default {
   },
   setup() {
     const store = useEcosystemStore()
-    return { store }
+    return { store, generateSlug }
   }
 }
 </script>

--- a/ui/src/components/ProjectModal.vue
+++ b/ui/src/components/ProjectModal.vue
@@ -16,6 +16,7 @@
               hide-details
               persistent-placeholder
               required
+              @change="generateSlug(form.title, $refs.slug)"
             />
           </v-col>
         </v-row>
@@ -32,6 +33,7 @@
               persistent-hint
               persistent-placeholder
               required
+              ref="slug"
             />
           </v-col>
         </v-row>
@@ -51,6 +53,7 @@
 </template>
 <script>
 import ProjectSelector from './ProjectSelector.vue'
+import { generateSlug } from '@/utils/datasources'
 
 export default {
   components: { ProjectSelector },
@@ -102,6 +105,7 @@ export default {
     }
   },
   methods: {
+    generateSlug,
     onClick() {
       if (this.edit) {
         this.onEdit()

--- a/ui/src/composables/useProjects.js
+++ b/ui/src/composables/useProjects.js
@@ -38,7 +38,7 @@ export function useProjects() {
     Object.assign(modal.value, {
       isOpen: true,
       edit: false,
-      name: null,
+      name: '',
       title: null
     })
   }

--- a/ui/src/utils/datasources.js
+++ b/ui/src/utils/datasources.js
@@ -76,4 +76,11 @@ const getTaskArgs = (datasource, category, url) => {
   }
 }
 
-export { guessDatasource, getTaskArgs }
+const generateSlug = (fromText, toFieldRef) => {
+  if (fromText && toFieldRef.modelValue?.length === 0) {
+    const slug = fromText.trim().replace(/\s+/g, '-').toLowerCase()
+    toFieldRef.$emit('update:modelValue', slug)
+  }
+}
+
+export { guessDatasource, getTaskArgs, generateSlug }


### PR DESCRIPTION
This PR makes the ecosystem description field optional and automatically generates a slug from the ecosystem and project titles if there is not one, converting spaces to hyphens and making it lowercase.
Fixes #87.