### PR TITLE
Add rollover index to archivist settings

### DIFF
--- a/src/grimoirelab/core/config/settings.py
+++ b/src/grimoirelab/core/config/settings.py
@@ -363,6 +363,9 @@ GRIMOIRELAB_ARCHIVIST = {
     in ("true", "1"),
     "BLOCK_TIMEOUT": int(os.environ.get("GRIMOIRELAB_ARCHIVIST_BLOCK_TIMEOUT", 60000)),
     "BULK_SIZE": int(os.environ.get("GRIMOIRELAB_ARCHIVIST_BULK_SIZE", 100)),
+    "ROLLOVER_INDICES": os.environ.get("GRIMOIRELAB_ARCHIVIST_ROLLOVER_INDICES", "True").lower()
+    in ("true", "1"),
+    "ROLLOVER_SIZE": os.environ.get("GRIMOIRELAB_ARCHIVIST_ROLLOVER_SIZE", "20gb"),
 }
 
 #

--- a/src/grimoirelab/core/consumers/archivist.py
+++ b/src/grimoirelab/core/consumers/archivist.py
@@ -24,8 +24,9 @@ import warnings
 
 import certifi
 import urllib3
+import opensearchpy.exceptions
 
-from opensearchpy import OpenSearch, RequestError
+from opensearchpy import OpenSearch
 from urllib3.util import create_urllib3_context
 
 from .consumer import Consumer, Entry
@@ -36,7 +37,7 @@ if typing.TYPE_CHECKING:
 
 
 BULK_SIZE = 100
-
+ROLLOVER_SIZE = "20gb"
 DEFAULT_INDEX = "events"
 
 MAPPING = {
@@ -114,18 +115,14 @@ class OpenSearchArchivist(Consumer):
     ):
         super().__init__(**kwargs)
 
-        auth = None
-        if user and password:
-            auth = (user, password)
-
-        if not verify_certs:
-            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-            warnings.filterwarnings("ignore", message=".*verify_certs.*")
-
         self.index = index
         self.bulk_size = bulk_size
-
-        self._setup_opensearch(url, auth, verify_certs)
+        self.client = create_opensearch_client(
+            url=url,
+            user=user,
+            password=password,
+            verify_certs=verify_certs,
+        )
 
     def process_entries(self, entries: Iterable[Entry], recovery: bool = False) -> None:
         """Process entries and store them in the OpenSearch instance."""
@@ -168,44 +165,7 @@ class OpenSearchArchivist(Consumer):
                     entry_map.pop(failed_id, None)
                 self.ack_entries(list(entry_map.values()))
 
-    def _create_index(self, index: str) -> None:
-        """Create an index in the OpenSearch instance."""
-
-        try:
-            self.client.indices.create(index=index, body=MAPPING)
-        except RequestError as e:
-            if e.error == "resource_already_exists_exception":
-                pass
-            else:
-                raise
-
-    def _setup_opensearch(self, url: str, auth: tuple[str, str] | None, verify_certs: bool) -> None:
-        """Set up the OpenSearch client.
-
-        :param url: OpenSearch URL
-        :param auth: Authentication credentials (user, password)
-        :param verify_certs: Whether to verify SSL certificates
-        """
-        context = None
-        if verify_certs:
-            # Use certificates from the local system and certifi
-            context = create_urllib3_context()
-            context.load_default_certs()
-            context.load_verify_locations(certifi.where())
-
-        self.client = OpenSearch(
-            hosts=[url],
-            http_auth=auth,
-            http_compress=True,
-            verify_certs=verify_certs,
-            ssl_context=context,
-            ssl_show_warn=False,
-            max_retries=3,
-            retry_on_timeout=True,
-        )
-        self._create_index(self.index)
-
-    def _bulk(self, body: str, index: str) -> (int, list):
+    def _bulk(self, body: str, index: str) -> tuple[int, list]:
         """Store data in the OpenSearch instance.
 
         :param body: body of the bulk request
@@ -248,6 +208,8 @@ class OpenSearchArchivistPool(ConsumerPool):
         password: str | None = None,
         index: str = DEFAULT_INDEX,
         bulk_size: int = BULK_SIZE,
+        rollover_indices: bool = True,
+        rollover_size: str = ROLLOVER_SIZE,
         verify_certs: bool = False,
         **kwargs,
     ):
@@ -258,15 +220,190 @@ class OpenSearchArchivistPool(ConsumerPool):
         self.password = password
         self.index = index
         self.bulk_size = bulk_size
+        self.rollover_indices = rollover_indices
+        self.rollover_size = rollover_size
         self.verify_certs = verify_certs
 
     @property
     def extra_consumer_kwargs(self):
-        return {
+        kwargs = {
             "url": self.url,
             "user": self.user,
             "password": self.password,
-            "index": self.index,
             "bulk_size": self.bulk_size,
             "verify_certs": self.verify_certs,
         }
+        if self.rollover_indices:
+            kwargs["index"] = f"{self.index}-write"
+        else:
+            kwargs["index"] = self.index
+
+        return kwargs
+
+    def _setup_consumer_pool(self, burst: bool = False):
+        """Configure OpenSearch before starting the workers."""
+
+        client = create_opensearch_client(
+            url=self.url,
+            user=self.user,
+            password=self.password,
+            verify_certs=self.verify_certs,
+        )
+        if self.rollover_indices:
+            self._configure_rollover_indices(client)
+        else:
+            self._create_index(client, index=self.index, body=MAPPING)
+
+    def _configure_rollover_indices(self, client: OpenSearch):
+        """Configure rollover indices in OpenSearch.
+
+        The alias is the index name provided by the user.
+
+        A rollover policy will be created to manage the rollover of indices
+        based on the specified size. The index pattern for the policy will be
+        `<alias>-*`, where `<alias>` is the provided index name.
+
+        The first index will be created with the name `<alias>-000001` and will be
+        associated with two aliases: `<alias>` (read alias) and `<alias>-write`
+        (write alias).
+
+        The read alias points to all indices associated with the alias, while the
+        write alias points to the current index where new data will be written.
+        When the current index reaches the specified size, a new index will be
+        created and the write alias will be updated to point to the new index.
+        This allows indexes to be rolled over without interrupting write operations.
+        """
+        alias_name = self.index
+        alias_write_name = f"{alias_name}-write"
+        policy_id = f"{alias_name}_rollover_policy"
+        index_pattern = f"{alias_name}-*"
+
+        self._create_rollover_policy(client, policy_id, index_pattern)
+        self._create_rollover_index(client, alias_name, alias_write_name)
+
+    def _create_rollover_policy(self, client: OpenSearch, policy_id: str, index_pattern: str):
+        """Create rollover policy for the OpenSearch index."""
+
+        rollover_policy = {
+            "policy": {
+                "policy_id": policy_id,
+                "description": "Rollover index when it reaches a certain size",
+                "default_state": "rollover",
+                "states": [
+                    {
+                        "name": "rollover",
+                        "actions": [
+                            {
+                                "retry": {"count": 3, "backoff": "exponential", "delay": "5m"},
+                                "rollover": {"min_size": self.rollover_size, "copy_alias": True},
+                            }
+                        ],
+                        "transitions": [],
+                    }
+                ],
+                "ism_template": [
+                    {
+                        "index_patterns": [index_pattern],
+                        "priority": 100,
+                    }
+                ],
+            }
+        }
+
+        try:
+            client.transport.perform_request(
+                method="PUT",
+                url=f"/_plugins/_ism/policies/{policy_id}",
+                body=json.dumps(rollover_policy),
+            )
+            self.logger.info(f"Created rollover policy: {policy_id}")
+        except opensearchpy.exceptions.ConflictError:
+            self.logger.info(f"Rollover policy '{policy_id}' already exists.")
+        except Exception as e:
+            self.logger.error(f"Failed to create rollover policy: {e}")
+            raise
+
+    def _create_rollover_index(self, client: OpenSearch, alias_name: str, alias_write_name: str):
+        """Create the initial rollover index and alias if they don't exist."""
+
+        index_template = {
+            "index_patterns": [f"{alias_name}-*"],
+            "template": {
+                "settings": {
+                    "index.plugins.index_state_management.rollover_alias": alias_write_name
+                },
+                "mappings": MAPPING["mappings"],
+            },
+        }
+        index_body = {"aliases": {alias_write_name: {"is_write_index": True}, alias_name: {}}}
+
+        res = client.indices.put_index_template(
+            name=f"{alias_name}_ism_rollover", body=index_template
+        )
+        if res and res.get("acknowledged", False):
+            self.logger.info("Created index template for rollover indices.")
+
+        self._create_index(client, index=f"{alias_name}-000001", body=index_body)
+
+    def _create_index(self, client: OpenSearch, index, body=None):
+        """Create the OpenSearch index with the specified body."""
+
+        res = client.indices.create(index=index, body=body, ignore=400)
+        if res and res.get("acknowledged", False):
+            self.logger.info(f"Created index: {index}")
+        else:
+            if "resource_already_exists_exception" in res.get("error", {}).get("type", ""):
+                self.logger.info(f"Index {index} already exists.")
+            else:
+                self.logger.error(
+                    f"Failed to create index: {res.get('error', {}).get('reason', 'Unknown error')}"
+                )
+                raise opensearchpy.exceptions.ConnectionError()
+
+
+def create_opensearch_client(
+    url: str,
+    user: str | None = None,
+    password: str | None = None,
+    verify_certs: bool = False,
+) -> OpenSearch:
+    """Create an OpenSearch client.
+
+    Use the `certifi` package to handle SSL certificates and
+    local system certificates if `verify_certs` is True.
+    If `verify_certs` is False, ignore SSL warnings.
+
+    :param url: OpenSearch URL
+    :param user: OpenSearch username
+    :param password: OpenSearch password
+    :param verify_certs: Whether to verify SSL certificates
+    :return: OpenSearch client instance
+    """
+    context = None
+
+    if verify_certs:
+        # Use certificates from the local system and certifi
+        context = create_urllib3_context()
+        context.load_default_certs()
+        context.load_verify_locations(certifi.where())
+    else:
+        # Ignore SSL warnings if not verifying certificates
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+        warnings.filterwarnings("ignore", message=".*verify_certs.*")
+
+    auth = None
+    if user and password:
+        auth = (user, password)
+
+    client = OpenSearch(
+        hosts=[url],
+        http_auth=auth,
+        http_compress=True,
+        verify_certs=verify_certs,
+        ssl_context=context,
+        ssl_show_warn=False,
+        max_retries=3,
+        retry_on_timeout=True,
+    )
+
+    return client

--- a/src/grimoirelab/core/runner/commands/run.py
+++ b/src/grimoirelab/core/runner/commands/run.py
@@ -260,6 +260,7 @@ def archivists(workers: int, verbose: bool, burst: bool):
 
     pool = OpenSearchArchivistPool(
         # Consumer parameters
+        connection=django_rq.get_connection(),
         stream_name=settings.GRIMOIRELAB_EVENTS_STREAM_NAME,
         group_name="opensearch-archivist",
         num_consumers=workers,
@@ -272,6 +273,8 @@ def archivists(workers: int, verbose: bool, burst: bool):
         index=settings.GRIMOIRELAB_ARCHIVIST["STORAGE_INDEX"],
         bulk_size=settings.GRIMOIRELAB_ARCHIVIST["BULK_SIZE"],
         verify_certs=settings.GRIMOIRELAB_ARCHIVIST["STORAGE_VERIFY_CERT"],
+        rollover_indices=settings.GRIMOIRELAB_ARCHIVIST["ROLLOVER_INDICES"],
+        rollover_size=settings.GRIMOIRELAB_ARCHIVIST["ROLLOVER_SIZE"],
     )
     pool.start(burst=burst)
 
@@ -296,6 +299,7 @@ def ushers(workers: int, verbose: bool, burst: bool):
 
     pool = SortingHatConsumerPool(
         # Consumer parameters
+        connection=django_rq.get_connection(),
         stream_name=settings.GRIMOIRELAB_EVENTS_STREAM_NAME,
         group_name="sortinghat-identities",
         num_consumers=workers,

--- a/tests/integration/test_archivist.py
+++ b/tests/integration/test_archivist.py
@@ -21,6 +21,8 @@ import json
 import logging
 import time
 
+import pytest
+
 from grimoirelab.core.consumers.archivist import OpenSearchArchivist, OpenSearchArchivistPool
 from .conftest import EVENTS_INDEX, STREAM_NAME, CONSUMER_GROUP, CONSUMER_NAME, opensearch
 
@@ -107,9 +109,52 @@ def test_insert_many_huge_events(redis_conn, opensearch_conn):
     assert pending["pending"] == 0
 
 
-def archivist_pool(redis_conn, opensearch_conn):
+def test_archivist_pool(redis_conn, opensearch_conn):
     """
     Test whether an archivist pool inserts items in OpenSearch
+
+    :param redis_conn: Redis connection
+    :param opensearch_conn: OpenSearch connection
+    """
+    # Create events
+    rstream = RedisStream(redis_conn, STREAM_NAME)
+    events = json.loads(read_file("tests/integration/data/events.json"))
+    for i, event in enumerate(events):
+        rstream.add_entry(event=event, message_id=f"{i + 1}-0")
+
+    pool = OpenSearchArchivistPool(
+        connection=redis_conn,
+        stream_name=STREAM_NAME,
+        group_name=CONSUMER_GROUP,
+        num_consumers=5,
+        stream_block_timeout=500,
+        verbose=True,
+        url=f"http://localhost:{opensearch.get_exposed_port(9200)}",
+        user="admin",
+        password="admin",
+        index=EVENTS_INDEX,
+        rollover_indices=False,
+        bulk_size=100,
+        verify_certs=False,
+    )
+    pool.start(burst=True)
+
+    # Wait the workers to insert the events
+    time.sleep(5)
+
+    # Check the events are in OpenSearch
+    result = opensearch_conn.count(index=EVENTS_INDEX)
+    assert result["count"] == len(events)
+
+    # Check that the events are not in Redis
+    pending = redis_conn.xpending(STREAM_NAME, CONSUMER_GROUP)
+    assert pending["pending"] == 0
+
+
+@pytest.mark.parametrize("opensearch_conn", [True], indirect=True)
+def test_archivist_pool_with_rollover(redis_conn, opensearch_conn):
+    """
+    Test whether an archivist pool with rollover inserts items in OpenSearch
 
     :param redis_conn: Redis connection
     :param opensearch_conn: OpenSearch connection
@@ -121,6 +166,7 @@ def archivist_pool(redis_conn, opensearch_conn):
         rstream.add_entry(event=event, message_id=f"{i + 1}-0")
 
     pool = OpenSearchArchivistPool(
+        connection=redis_conn,
         stream_name=STREAM_NAME,
         group_name=CONSUMER_GROUP,
         num_consumers=5,
@@ -130,10 +176,15 @@ def archivist_pool(redis_conn, opensearch_conn):
         user="admin",
         password="admin",
         index=EVENTS_INDEX,
+        rollover_indices=True,
+        rollover_size="15kb",
         bulk_size=100,
         verify_certs=False,
     )
     pool.start(burst=True)
+
+    # Wait the workers to insert the events
+    time.sleep(5)
 
     # Check the events are in OpenSearch
     result = opensearch_conn.count(index=EVENTS_INDEX)
@@ -142,3 +193,27 @@ def archivist_pool(redis_conn, opensearch_conn):
     # Check that the events are not in Redis
     pending = redis_conn.xpending(STREAM_NAME, CONSUMER_GROUP)
     assert pending["pending"] == 0
+
+    # Check a new index was created with the EVENTS_INDEX alias
+    indices = opensearch_conn.indices.get_alias(name=EVENTS_INDEX)
+
+    assert len(indices) == 1
+
+    # Check didn't fail to create the rollover policy
+    stderr_logs, stdout_logs = opensearch.get_logs()
+    expected = (
+        f"Index [{EVENTS_INDEX}-000001] matched ISM policy template"
+        f" and will be managed by {EVENTS_INDEX}_rollover_policy"
+    )
+    assert expected in stderr_logs.decode("utf-8")
+
+    # Check policy exists and has expected content
+    policy = opensearch_conn.transport.perform_request(
+        "GET", f"/_plugins/_ism/policies/{EVENTS_INDEX}_rollover_policy"
+    )
+    assert policy["policy"]["policy_id"] == f"{EVENTS_INDEX}_rollover_policy"
+    assert policy["policy"]["ism_template"][0]["index_patterns"] == [f"{EVENTS_INDEX}-*"]
+    assert policy["policy"]["default_state"] == "rollover"
+    assert policy["policy"]["states"][0]["name"] == "rollover"
+    assert policy["policy"]["states"][0]["actions"][0]["rollover"]["min_size"] == "15kb"
+    assert policy["policy"]["states"][0]["actions"][0]["rollover"]["copy_alias"]

--- a/tests/unit/consumers/test_archivist.py
+++ b/tests/unit/consumers/test_archivist.py
@@ -20,7 +20,7 @@ import logging
 
 from unittest.mock import patch, MagicMock
 
-from grimoirelab.core.consumers.archivist import OpenSearchArchivist, Entry, MAPPING
+from grimoirelab.core.consumers.archivist import OpenSearchArchivist, Entry
 
 from ..base import GrimoireLabTestCase
 
@@ -61,7 +61,6 @@ class TestOpenSearchArchivist(GrimoireLabTestCase):
             max_retries=3,
             retry_on_timeout=True,
         )
-        mock_client.indices.create.assert_called_once_with(index="test_index", body=MAPPING)
 
     @patch("grimoirelab.core.consumers.archivist.OpenSearch")
     def test_process_entries(self, mock_opensearch):

--- a/tests/unit/consumers/test_consumer_pool.py
+++ b/tests/unit/consumers/test_consumer_pool.py
@@ -46,6 +46,7 @@ class TestConsumerPool(GrimoireLabTestCase):
         """Test whether the pool is initialized correctly"""
 
         pool = SampleConsumerPool(
+            connection=self.conn,
             stream_name="test_stream",
             group_name="test_group",
             num_consumers=10,
@@ -65,6 +66,7 @@ class TestConsumerPool(GrimoireLabTestCase):
         """Test whether the consumers are cleaned up correctly"""
 
         pool = SampleConsumerPool(
+            connection=self.conn,
             stream_name="test_stream",
             group_name="test_group",
             num_consumers=10,
@@ -92,6 +94,7 @@ class TestConsumerPool(GrimoireLabTestCase):
         """Test whether consumers are restored correctly"""
 
         pool = SampleConsumerPool(
+            connection=self.conn,
             stream_name="test_stream",
             group_name="test_group",
             num_consumers=10,
@@ -123,6 +126,7 @@ class TestConsumerPool(GrimoireLabTestCase):
             os.kill(pid, signal.SIGTERM)
 
         pool = SampleConsumerPool(
+            connection=self.conn,
             stream_name="test_stream",
             group_name="test_group",
             num_consumers=10,


### PR DESCRIPTION
Previously, all events were stored in a single index, which reduced performance in OpenSearch as the index grew too large.

This change introduces support for defining a rollover policy in the Archivist configuration. The policy allows indices to roll over automatically once they reach a specified size, improving search and indexing performance in OpenSearch.

Rollover is now the default behavior, but inserting into a single index remains supported if explicitly configured.

New environment variables with their default values are:
- GRIMOIRELAB_ARCHIVIST_ROLLOVER_INDICES = True
- GRIMOIRELAB_ARCHIVIST_ROLLOVER_SIZE = 20gb