### PR TITLE
Optimize event processing with pipeline and fix a bug

### DIFF
--- a/src/grimoirelab/core/consumers/consumer.py
+++ b/src/grimoirelab/core/consumers/consumer.py
@@ -193,7 +193,7 @@ class Consumer:
 
                 yield Entry(message_id=message_id, event=json.loads(message_data))
 
-            if response[0] == b"0-0":
+            if not messages:
                 break
 
             if self._stop_event.is_set():

--- a/tests/integration/test_archivist.py
+++ b/tests/integration/test_archivist.py
@@ -92,9 +92,6 @@ def test_insert_many_huge_events(redis_conn, opensearch_conn):
 
     # Simulate the archivist recovering the entries
     recovered_entries = archivist.recover_stream_entries(recover_idle_time=1)
-    recovered_entries = list(recovered_entries)
-    assert len(recovered_entries) == 10
-
     archivist.process_entries(recovered_entries, recovery=True)
 
     # Wait for OpenSearch to process the event count


### PR DESCRIPTION
Use a Redis pipeline to batch commands for adding events. This improves performance by reducing the number of round trips to the Redis server, especially when processing a large number of events.

This PR also fixes a bug. When pending entries existed in Redis but hadn't reached the minimum idle time, XAUTOCLAIM didn't return '0-0' as the next ID. Instead, it returned a different ID, causing the consumer to remain stuck until all recovered entries were processed, blocking new entries from being handled.

Fixes https://github.com/chaoss/grimoirelab/issues/760